### PR TITLE
Added update plugin command

### DIFF
--- a/ServiceProvider.php
+++ b/ServiceProvider.php
@@ -328,6 +328,7 @@ class ServiceProvider extends ModuleServiceProvider
         $this->registerConsoleCommand('plugin.install', 'System\Console\PluginInstall');
         $this->registerConsoleCommand('plugin.remove', 'System\Console\PluginRemove');
         $this->registerConsoleCommand('plugin.refresh', 'System\Console\PluginRefresh');
+        $this->registerConsoleCommand('plugin.update', 'System\Console\PluginUpdate');
 
         /*
          * Override clear cache command

--- a/console/PluginUpdate.php
+++ b/console/PluginUpdate.php
@@ -1,0 +1,71 @@
+<?php namespace System\Console;
+
+use Illuminate\Console\Command;
+use System\Classes\UpdateManager;
+use System\Classes\PluginManager;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class PluginUpdate extends Command
+{
+
+    /**
+     * The console command name.
+     * @var string
+     */
+    protected $name = 'plugin:update';
+
+    /**
+     * The console command description.
+     * @var string
+     */
+    protected $description = 'Updates an existing plugin';
+
+    /**
+     * Create a new command instance.
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     * @return void
+     */
+    public function fire()
+    {
+        $pluginName = $this->argument('name');
+        $pluginName = PluginManager::instance()->normalizeIdentifier($pluginName);
+
+        $manager = UpdateManager::instance();
+
+        $this->output->writeln('<info>Updating plugin...</info>');
+        $manager->updatePlugin($pluginName);
+
+        foreach ($manager->getNotes() as $note) {
+            $this->output->writeln($note);
+        }
+    }
+
+    /**
+     * Get the console command arguments.
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the plugin. Eg: AuthorName.PluginName'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Update plugin command provides a way to update custom plugins. Helpful when developer has updated custom plugin and site is already in production (has data that cant be deleted by command as plugin:refresh)
